### PR TITLE
Add support for Deluge 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.idea
+.vagrant
+.DS_Store
+.deluge-automanage.toml
+bin/

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ host     = "localhost"  # deluge daemon hostname/ip
 port     = 30000        # deluge daemon port
 login    = "my-user"    # deluge daemon user
 password = "my-pass"    # deluge daemon password
+version  = "v2"         # deluge version (v1 or v2)
  
 [rules]
 enabled              = true   # enable or disable rules

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -36,12 +36,24 @@ var addCmd = &cobra.Command{
 		// first arg is path to torrent file
 		filePath := args[0]
 
-		deluge := delugeclient.NewV1(delugeclient.Settings{
-			Hostname: Config.Deluge.Host,
-			Port:     Config.Deluge.Port,
-			Login:    Config.Deluge.Login,
-			Password: Config.Deluge.Password,
-		})
+		var deluge delugeclient.DelugeClient
+
+		if Config.Deluge.Version == "v2" {
+			deluge = delugeclient.NewV2(delugeclient.Settings{
+				Hostname: Config.Deluge.Host,
+				Port:     Config.Deluge.Port,
+				Login:    Config.Deluge.Login,
+				Password: Config.Deluge.Password,
+			})
+
+		} else {
+			deluge = delugeclient.NewV1(delugeclient.Settings{
+				Hostname: Config.Deluge.Host,
+				Port:     Config.Deluge.Port,
+				Login:    Config.Deluge.Login,
+				Password: Config.Deluge.Password,
+			})
+		}
 
 		// perform connection to Deluge server
 		err := deluge.Connect()

--- a/internal/domain/config.go
+++ b/internal/domain/config.go
@@ -5,6 +5,7 @@ type DelugeConfig struct {
 	Port     uint   `mapstructure:"port"`
 	Login    string `mapstructure:"login"`
 	Password string `mapstructure:"password"`
+	Version  string `mapstructure:"version"`
 }
 
 type Rules struct {


### PR DESCRIPTION
Add support for Deluge 2.

* Add example config `.deluge-automanage.toml.example`
* Update `README.md`